### PR TITLE
enable radiolib_godmode, use lib_extra_dirs

### DIFF
--- a/lib/RadioLib/src/BuildOpt.h
+++ b/lib/RadioLib/src/BuildOpt.h
@@ -69,7 +69,7 @@
  *          Failure to heed the above warning may result in bricked module.
  */
 #if !defined(RADIOLIB_GODMODE)
-  #define RADIOLIB_GODMODE (0)
+  #define RADIOLIB_GODMODE (1)
 #endif
 
 /*

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ board_build.arduino.memory_type = qio_opi
 board_build.flash_mode = qio
 
 ; Libraries path for both local libs and TDeck example libs
-lib_dirs = 
+lib_extra_dirs =
     ${PROJECT_DIR}/lib
 
 ; Deps


### PR DESCRIPTION
* Enable `radiolib_godmode`
* Replaced `lib_dirs` with `lib_extra_dirs`. I did this because I was getting the compile error:
    ```
    unknown configuration option lib_dirs
    ```